### PR TITLE
Allow users to attend events

### DIFF
--- a/app/Http/Controllers/AttachEventAttendee.php
+++ b/app/Http/Controllers/AttachEventAttendee.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CalendarEvent;
+use Illuminate\Http\Request;
+
+class AttachEventAttendee extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(CalendarEvent $event, Request $request)
+    {
+        $data = $request->validate(['attending' => 'required|boolean']);
+        
+        if($data['attending']) {
+            $request->user()->events()->syncWithoutDetaching($event);
+        } else {
+            $request->user()->events()->detach($event);
+        }
+    }
+}

--- a/app/Http/Controllers/ListEventAttendees.php
+++ b/app/Http/Controllers/ListEventAttendees.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CalendarEvent;
+use Illuminate\Http\Request;
+
+class ListEventAttendees extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(CalendarEvent $event)
+    {
+        return $event->users()->select(['id', 'name', 'avatar'])->get();
+    }
+}

--- a/app/Http/Controllers/ListEvents.php
+++ b/app/Http/Controllers/ListEvents.php
@@ -5,30 +5,24 @@ namespace App\Http\Controllers;
 use App\Models\CalendarEvent;
 use Illuminate\Http\Request;
 
-class CalendarEventController extends Controller
+class ListEvents extends Controller
 {
-    public function index(Request $request)
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request)
     {
-        return CalendarEvent::select([
+        return CalendarEvent::query()
+            ->select([
                 'id',
                 'title', 'description',
                 'location', 'latitude', 'longitude',
                 'start_date', 'end_date',
                 'calendar_name', 'image_url', 'url'
             ])
+            ->withCount('users as attendees')
             ->whereDate('end_date', '>=', now())
             ->orderBy('start_date')
             ->get();
-    }
-
-    public function show(CalendarEvent $event, Request $request)
-    {
-        return $event->only([
-            'id',
-            'title', 'description',
-            'location', 'latitude', 'longitude',
-            'start_date', 'end_date',
-            'calendar_name', 'image_url', 'url'
-        ]);
     }
 }

--- a/app/Http/Controllers/ShowEvent.php
+++ b/app/Http/Controllers/ShowEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CalendarEvent;
+use Illuminate\Http\Request;
+
+class ShowEvent extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(CalendarEvent $event, Request $request)
+    {
+        return $event->loadCount('users as attendees')->only([
+            'id',
+            'title', 'description',
+            'location', 'latitude', 'longitude',
+            'start_date', 'end_date',
+            'calendar_name', 'image_url', 'url',
+            'attendees'
+        ]);
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -7,8 +7,8 @@ use Illuminate\Http\Request;
 
 class UserController extends Controller
 {
-    public function show()
+    public function show(Request $request)
     {
-        return auth()->user();
+        return $request->user();
     }
 }

--- a/app/Models/CalendarEvent.php
+++ b/app/Models/CalendarEvent.php
@@ -18,4 +18,9 @@ class CalendarEvent extends Model
         'start_date' => 'datetime',
         'end_date' => 'datetime'
     ];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,5 +13,10 @@ class User extends Authenticatable
 
     protected $guarded = [];
 
-    protected $hidden = ['expo_token'];
+    protected $hidden = ['expo_token', 'pivot'];
+
+    public function events()
+    {
+        return $this->belongsToMany(CalendarEvent::class);
+    }
 }

--- a/database/migrations/2023_07_04_133749_create_calendar_event_user_table.php
+++ b/database/migrations/2023_07_04_133749_create_calendar_event_user_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\CalendarEvent;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('calendar_event_user', function (Blueprint $table) {
+            $table->foreignIdFor(CalendarEvent::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->unique(['calendar_event_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('calendar_event_user');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Http\Controllers\AttachEventAttendee;
 use App\Http\Controllers\MobileAuthController;
-use App\Http\Controllers\CalendarEventController;
 use App\Http\Controllers\CourseCatalogController;
 use App\Http\Controllers\FeedbackController;
 use App\Http\Controllers\HoursController;
@@ -9,6 +9,9 @@ use App\Http\Controllers\MapController;
 use App\Http\Controllers\MenuController;
 use App\Http\Controllers\NewsController;
 use App\Http\Controllers\NewsSource;
+use App\Http\Controllers\ListEventAttendees;
+use App\Http\Controllers\ListEvents;
+use App\Http\Controllers\ShowEvent;
 use App\Http\Controllers\TransitController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
@@ -29,7 +32,13 @@ Route::get('hours', HoursController::class);
 Route::get('news/{source}', NewsController::class)->whereIn('source', array_column(NewsSource::cases(), 'value'));
 
 // Calendar Events
-Route::apiResource('events', CalendarEventController::class)->only(['index', 'show']);
+Route::get('events', ListEvents::class);
+Route::get('events/{event}', ShowEvent::class);
+
+Route::middleware('auth:sanctum')->group(function() {
+    Route::get('events/{event}/attendees', ListEventAttendees::class);
+    Route::post('events/{event}/attendees', AttachEventAttendee::class);
+});
 
 // Public Transit
 Route::get('transit', TransitController::class);


### PR DESCRIPTION
- Adds `attendees` field to `/events` and `/events/:id` which is the number of users that have RSVP'd
- Adds `/events/:id/attendees` endpoint
  - `GET` lists attendees
  - `POST` with body `{ "attending": boolean }` adds/removes a yes RSVP